### PR TITLE
Track overall metrics for other than default queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pyc
+.idea
+boto.cfg
+launch.sh

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Finally, the following metrics are sent as overalls:
     CELERY_BROKER_URL="amqp://guest@localhost:5672//" \
     TASK_MONITOR_CW_TASK_NAMES=task,names,to,monitor,comma,separated \
     TASK_MONITOR_CW_NAMESPACE=my-custom-aws-namespace \
+    TASK_MONITOR_CW_QUEUES=comma-separated-queue-names-default-celery \
     BOTO_CONFIG=myboto.cfg \
     bash bin/task_monitor -c lib.CloudWatchCamera --factory=lib.CloudWatchCameraFactory --freq=60
     ```

--- a/task_monitor/lib/__init__.py
+++ b/task_monitor/lib/__init__.py
@@ -1,4 +1,3 @@
-
 __author__ = 'nathan.muir'
 
 from task_monitor import TaskMonitor

--- a/task_monitor/lib/camera.py
+++ b/task_monitor/lib/camera.py
@@ -1,13 +1,12 @@
 __author__ = 'nathan.muir'
 
-
 from celery.utils.timer2 import Timer
 from celery.utils.dispatch import Signal
 
 from import_class import import_class
 
-class CameraFactory(object):
 
+class CameraFactory(object):
     def __init__(self, class_name):
         self.frequency = 60.0
         self.c = import_class(class_name)

--- a/task_monitor/lib/cloudwatch_camera.py
+++ b/task_monitor/lib/cloudwatch_camera.py
@@ -1,13 +1,16 @@
 __author__ = 'nathan.muir'
 
-from camera import Camera, CameraFactory
-import boto.ec2.cloudwatch
-import sys, traceback, os
-import json
+import sys
+import traceback
+import os
 import re
 
-class CloudWatchCameraFactory(CameraFactory):
+import boto.ec2.cloudwatch
 
+from camera import Camera, CameraFactory
+
+
+class CloudWatchCameraFactory(CameraFactory):
     def camera(self, state):
         kwargs = {
             'freq': self.frequency,
@@ -16,10 +19,12 @@ class CloudWatchCameraFactory(CameraFactory):
             'aws_connection': boto.ec2.cloudwatch.CloudWatchConnection()
         }
         if 'TASK_MONITOR_CW_TASK_NAMES' in os.environ:
-            kwargs['task_names'] = [x.strip() for x in os.environ['TASK_MONITOR_CW_TASK_NAMES'].split(',')]
+            kwargs['task_names'] = [x.strip() for x in os.environ[
+                'TASK_MONITOR_CW_TASK_NAMES'].split(',')]
 
         if 'TASK_MONITOR_CW_NAMESPACE' in os.environ:
-            kwargs['cloud_watch_namespace'] = os.environ['TASK_MONITOR_CW_NAMESPACE'].strip()
+            kwargs['cloud_watch_namespace'] = os.environ[
+                'TASK_MONITOR_CW_NAMESPACE'].strip()
 
         if 'TASK_MONITOR_CW_QUEUES' in os.environ:
             kwargs['queues'] = [x.strip() for x in os.environ[
@@ -31,11 +36,12 @@ class CloudWatchCameraFactory(CameraFactory):
 
 
 class CloudWatchCamera(Camera):
-
     clear_after = True
     _event_names = ('waiting', 'running', 'completed', 'failed')
 
-    def __init__(self, state, aws_connection, freq=1.0, task_names=None, cloud_watch_namespace='celery', base_dimensions=None, queues=None):
+    def __init__(self, state, aws_connection, freq=1.0, task_names=None,
+                 cloud_watch_namespace='celery', base_dimensions=None,
+                 queues=None):
         super(CloudWatchCamera, self).__init__(state, freq=freq)
         self.aws_connection = aws_connection
         self.cloud_watch_namespace = cloud_watch_namespace
@@ -80,13 +86,14 @@ class CloudWatchCamera(Camera):
             self.metrics.send()
         except:
             print "Exception in user code:"
-            print '-'*60
+            print '-' * 60
             traceback.print_exc(file=sys.stdout)
         finally:
             self.metrics = None
 
     def _metric_list(self):
-        return MetricList(self.cloud_watch_namespace, self.aws_connection, self.base_dimensions)
+        return MetricList(self.cloud_watch_namespace, self.aws_connection,
+                          self.base_dimensions)
 
     def _build_metrics(self, state):
         metrics = self._metric_list()
@@ -104,7 +111,9 @@ class CloudWatchCamera(Camera):
         task_events = self._fill_task_events(event_totals)
         for task_name, total_by_event in task_events.items():
             for event_name, total in total_by_event.items():
-                metrics.add('CeleryTaskEvent%s' % event_name.capitalize(), unit='Count', value=total, dimensions={'task': task_name})
+                metrics.add('CeleryTaskEvent%s' % event_name.capitalize(),
+                            unit='Count', value=total,
+                            dimensions={'task': task_name})
 
     def _fill_task_events(self, event_totals):
         task_events = {}
@@ -113,7 +122,8 @@ class CloudWatchCamera(Camera):
 
         for task_name, totals in event_totals.items():
             if task_name not in task_events:
-                task_events[task_name] = dict((en, 0) for en in self._event_names)
+                task_events[task_name] = dict(
+                    (en, 0) for en in self._event_names)
             for event_name, total in totals.items():
                 task_events[task_name][event_name] = total
         return task_events
@@ -121,29 +131,36 @@ class CloudWatchCamera(Camera):
     @staticmethod
     def _add_queue_times(metrics, time_to_start):
         for task_name, stats in time_to_start.items():
-            metrics.add('CeleryTaskQueuedTime', unit='Seconds', dimensions={'task': task_name}, stats=stats.__dict__.copy())
+            metrics.add('CeleryTaskQueuedTime', unit='Seconds',
+                        dimensions={'task': task_name},
+                        stats=stats.__dict__.copy())
 
     @staticmethod
     def _add_run_times(metrics, time_to_process):
         for task_name, stats in time_to_process.items():
-            metrics.add('CeleryTaskProcessingTime', unit='Seconds', dimensions={'task': task_name}, stats=stats.__dict__.copy())
-    @staticmethod
-    def _add_waiting_tasks(metrics, waiting_tasks, metric_key='', queue='celery'):
-        metrics.add('Celery%sQueueSize' % metric_key, unit='Count', value=waiting_tasks, dimensions={'queue': queue})
+            metrics.add('CeleryTaskProcessingTime', unit='Seconds',
+                        dimensions={'task': task_name},
+                        stats=stats.__dict__.copy())
 
     @staticmethod
-    def _add_running_tasks(metrics, running_tasks, metric_key='', queue='celery'):
-        metrics.add('Celery%sRunningTasks' % metric_key, unit='Count', value=running_tasks, dimensions={'queue': queue})
+    def _add_waiting_tasks(metrics, waiting_tasks, metric_key='',
+                           queue='celery'):
+        metrics.add('Celery%sQueueSize' % metric_key, unit='Count',
+                    value=waiting_tasks, dimensions={'queue': queue})
 
-
+    @staticmethod
+    def _add_running_tasks(metrics, running_tasks, metric_key='',
+                           queue='celery'):
+        metrics.add('Celery%sRunningTasks' % metric_key, unit='Count',
+                    value=running_tasks, dimensions={'queue': queue})
 
 
 def xchunk(arr, size):
     for x in xrange(0, len(arr), size):
-        yield arr[x:x+size]
+        yield arr[x:x + size]
+
 
 class MetricList(object):
-
     _metric_chunk_size = 20
 
     def __init__(self, namespace, aws_connection, base_dimensions=None):
@@ -175,12 +192,13 @@ class MetricList(object):
     def send(self):
         for metric_chunk in xchunk(self.metrics, self._metric_chunk_size):
             metrics = self._serialize(metric_chunk)
-            self.aws_connection.get_status('PutMetricData', metrics, verb="POST")
+            self.aws_connection.get_status('PutMetricData', metrics,
+                                           verb="POST")
 
 
 class Metric(object):
-
-    def __init__(self, name, unit=None, timestamp=None, value=None, stats=None, dimensions=None):
+    def __init__(self, name, unit=None, timestamp=None, value=None, stats=None,
+                 dimensions=None):
         self.name = name
         self.unit = unit
         self.timestamp = timestamp
@@ -212,7 +230,8 @@ class Metric(object):
         if self.stats:
             metric_data['StatisticValues.Maximum'] = self.stats['maximum']
             metric_data['StatisticValues.Minimum'] = self.stats['minimum']
-            metric_data['StatisticValues.SampleCount'] = self.stats['samplecount']
+            metric_data['StatisticValues.SampleCount'] = self.stats[
+                'samplecount']
             metric_data['StatisticValues.Sum'] = self.stats['sum']
         elif self.value is not None:
             metric_data['Value'] = self.value
@@ -232,11 +251,11 @@ class Metric(object):
                 if isinstance(dim_value, basestring):
                     dim_value = [dim_value]
                 for value in dim_value:
-                    params['%s.%d.Name' % (prefix, i+1)] = dim_name
-                    params['%s.%d.Value' % (prefix, i+1)] = value
+                    params['%s.%d.Name' % (prefix, i + 1)] = dim_name
+                    params['%s.%d.Value' % (prefix, i + 1)] = value
                     i += 1
             else:
-                params['%s.%d.Name' % (prefix, i+1)] = dim_name
+                params['%s.%d.Name' % (prefix, i + 1)] = dim_name
                 i += 1
 
     def __repr__(self):

--- a/task_monitor/lib/options.py
+++ b/task_monitor/lib/options.py
@@ -1,17 +1,25 @@
 import argparse
 
+
 class Options:
     parser = None
+
     def __init__(self):
         self.parser = self._init_parser()
 
     def _init_parser(self):
-        parser = argparse.ArgumentParser(description="Monitors Celery Task Events and provides statistics", usage='bin/task_monitor [options]')
+        description = "Monitors Celery Task Events and provides statistics"
+        parser = argparse.ArgumentParser(description=description,
+                                         usage='bin/task_monitor [options]')
 
-        parser.add_argument('-b', '--broker', default=None, help='''url to broker. default is 'amqp://guest@localhost//' ''')
-        parser.add_argument('-F', '--frequency', '--freq', type=float, default=60.0)
+        parser.add_argument('-b', '--broker', default=None,
+                            help="url to broker. "
+                                 "default is 'amqp://guest@localhost//'")
+        parser.add_argument('-F', '--frequency', '--freq',
+                            type=float, default=60.0)
         parser.add_argument('-c', '--camera', default='lib.PrintCamera')
-        parser.add_argument('-q', nargs='+', type=str, dest='queues', default='celery', help='Queues to monitor')
+        parser.add_argument('-q', nargs='+', type=str, dest='queues',
+                            default='celery', help='Queues to monitor')
         parser.add_argument('--factory')
         parser.set_defaults(blur=True)
         return parser

--- a/task_monitor/lib/options.py
+++ b/task_monitor/lib/options.py
@@ -11,6 +11,7 @@ class Options:
         parser.add_argument('-b', '--broker', default=None, help='''url to broker. default is 'amqp://guest@localhost//' ''')
         parser.add_argument('-F', '--frequency', '--freq', type=float, default=60.0)
         parser.add_argument('-c', '--camera', default='lib.PrintCamera')
+        parser.add_argument('-q', nargs='+', type=str, dest='queues', default='celery', help='Queues to monitor')
         parser.add_argument('--factory')
         parser.set_defaults(blur=True)
         return parser

--- a/task_monitor/lib/print_camera.py
+++ b/task_monitor/lib/print_camera.py
@@ -1,5 +1,4 @@
-
-
+from __future__ import print_function
 from stats import Stats
 from camera import Camera
 
@@ -8,33 +7,45 @@ class PrintCamera(Camera):
     clear_after = True
 
     def on_shutter(self, state):
-        print '-----'
+        print('-----')
 
-        print 'Time to Start'
+        print('Time to Start')
         total = Stats()
         for method_name, stats in state.time_to_start.items():
-            print "%s avg:%.2fs, max:%.2fs, min: %.2fs" % (method_name, stats.average() or -1.0 , stats.maximum or -1.0, stats.minimum or -1.0)
+            print(
+                "%s avg:%.2fs, max:%.2fs, min: %.2fs" %
+                method_name,
+                stats.average() or -1.0,
+                stats.maximum or -1.0,
+                stats.minimum or -1.0
+            )
             total += stats
 
-        print ''
-        print 'Time to Process'
+        print('\nTime to Process')
         total = Stats()
         for method_name, stats in state.time_to_process.items():
-            print "%s avg:%.2fs, max:%.2fs, min: %.2fs" % (method_name, stats.average() or -1.0, stats.maximum or -1.0, stats.minimum or -1.0)
+            print("%s avg:%.2fs, max:%.2fs, min: %.2fs" %
+                  (method_name,
+                   stats.average() or -1.0,
+                   stats.maximum or -1.0,
+                   stats.minimum or -1.0)
+            )
             total += stats
-        print "Total: avg:%.2fs, max:%.2fs, min: %.2fs" % (total.average() or -1.0, total.maximum or -1.0, total.minimum or -1.0)
+        print("Total: avg:%.2fs, max:%.2fs, min: %.2fs" %
+              (total.average() or -1.0,
+               total.maximum or -1.0,
+               total.minimum or -1.0)
+        )
 
-        print ''
-        print 'Event Totals'
+        print('\nEvent Totals')
         for method_name, totals in state.totals.items():
             for total_name, total in totals.items():
-                print "%s[%s]: %d" % (method_name, total_name, total)
+                print("%s[%s]: %d" % (method_name, total_name, total))
 
-        print ''
-        print 'Queue Sizes'
-        print 'Waiting Tasks: %d' % len(state.waiting_tasks)
-        print 'Running Tasks: %d' % len(state.running_tasks)
+        print('\nQueue Sizes')
+        print('Waiting Tasks: %d' % len(state.waiting_tasks))
+        print('Running Tasks: %d' % len(state.running_tasks))
 
-        print ''
-        print ''
+        print('')
+        print('')
 

--- a/task_monitor/lib/state.py
+++ b/task_monitor/lib/state.py
@@ -1,13 +1,16 @@
+from __future__ import print_function
+
 __author__ = 'nathan.muir'
 
 from collections import defaultdict
 import threading
+import sys
+import traceback
+
 from stats import Stats
 
-import sys, traceback
 
 class State(object):
-
     def __init__(self):
         self._mutex = threading.Lock()
 
@@ -29,10 +32,10 @@ class State(object):
             try:
                 return fun(*args, **kwargs)
             except:
-                print "Exception in user code:"
-                print '-'*60
+                print("Exception in user code:")
+                print('-' * 60)
                 traceback.print_exc(file=sys.stdout)
-                print '-'*60
+                print('-' * 60)
             finally:
                 if clear_after:
                     self._clear()
@@ -57,9 +60,12 @@ class State(object):
         with self._mutex:
             if event['uuid'] in self.task_types:
                 task_type = self.task_types[event['uuid']]
-                # only track averages for tasks that have a waiting-started timestamp
+                # only track averages for tasks that have a waiting-started
+                # timestamp
                 if event['uuid'] in self.waiting_tasks:
-                    self.time_to_start[task_type] += event['timestamp'] - self.waiting_tasks[event['uuid']]
+                    time = (event['timestamp'] -
+                            self.waiting_tasks[event['uuid']])
+                    self.time_to_start[task_type] += time
                     del self.waiting_tasks[event['uuid']]
 
                 self.running_tasks[event['uuid']] = event['timestamp']
@@ -70,13 +76,15 @@ class State(object):
             if event['uuid'] in self.task_types:
                 task_type = self.task_types[event['uuid']]
                 del self.task_types[event['uuid']]
-                # only track averages for tasks that have a waiting-started timestamp
+                # only track averages for tasks that have a waiting-started
+                # timestamp
                 if event['uuid'] in self.running_tasks:
-                    self.time_to_process[task_type] += event['timestamp'] - self.running_tasks[event['uuid']]
+                    time = (event['timestamp'] -
+                            self.running_tasks[event['uuid']])
+                    self.time_to_process[task_type] += time
                     del self.running_tasks[event['uuid']]
 
                 self.totals[task_type]['completed'] += 1
-
 
 
     def task_failed(self, event):

--- a/task_monitor/lib/stats.py
+++ b/task_monitor/lib/stats.py
@@ -1,5 +1,6 @@
 __author__ = 'nathan.muir'
 
+
 class Stats(object):
     def __init__(self, samplecount=0, total=0.0, minimum=None, maximum=None):
         self.samplecount = samplecount
@@ -27,11 +28,13 @@ class Stats(object):
 
     def __add__(self, value):
         if isinstance(value, Stats):
-            stats = Stats(self.samplecount + value.samplecount, self.sum + value.sum, self.minimum, self.maximum)
+            stats = Stats(self.samplecount + value.samplecount,
+                          self.sum + value.sum, self.minimum, self.maximum)
             stats._minmax(value.maximum)
             stats._minmax(value.minimum)
         else:
-            stats = Stats(self.samplecount, self.sum, self.minimum, self.maximum)
+            stats = Stats(self.samplecount, self.sum, self.minimum,
+                          self.maximum)
             stats += value
         return stats
 

--- a/task_monitor/lib/task_monitor.py
+++ b/task_monitor/lib/task_monitor.py
@@ -1,13 +1,14 @@
 __author__ = 'nathan.muir'
 from celery import Celery
+
 from state import State
 from import_class import import_class
 from camera import CameraFactory
 
-class TaskMonitor(object):
 
+class TaskMonitor(object):
     def __init__(self, options):
-       self.options = options
+        self.options = options
 
     def run(self):
         app = Celery(broker=self.options.broker)

--- a/task_monitor/main.py
+++ b/task_monitor/main.py
@@ -1,6 +1,5 @@
 __author__ = 'nathan.muir'
 
-import sys
 from lib import Options, TaskMonitor
 
 if __name__ == '__main__':


### PR DESCRIPTION
 I added CeleryNAMEQueueSize and CeleryNAMERunningTasks metrics (where NAME camel-cased queue name without non-alphanumeric symbols; same NAMEs would be added a sequential number to avoid name collisions). For default 'celery' queue it continues creating CeleryQueueSize and CeleryRunningTasks.