### PR TITLE
Now broker argument can be used

### DIFF
--- a/celery_cloudwatch/__main__.py
+++ b/celery_cloudwatch/__main__.py
@@ -77,7 +77,7 @@ def main():
     config = config_schema(config_schema(config))
     config_ccwatch = config['ccwatch']
     options = {
-        'broker': config_ccwatch.get('broker'),
+        'broker': args.broker if args.broker else config_ccwatch.get('broker') ,
         'camera': config_ccwatch.get('camera'),
         'verbose': config_ccwatch.get('verbose'),
         'config': config


### PR DESCRIPTION
Hey! Just I noticed that the --broker argument is not being used however I need it because I have a staging a production environment that has different brokers. 